### PR TITLE
docs: Fix tool READMEs to show MCP natural language usage

### DIFF
--- a/automagik_tools/tools/evolution_api/README.md
+++ b/automagik_tools/tools/evolution_api/README.md
@@ -147,84 +147,40 @@ Also available via the client are management helpers:
 
 See the function docstrings in `__init__.py` for more detail on each parameter and the example return shapes.
 
-## Usage examples (Python, async)
+## Usage examples (Natural Language with Claude)
 
-These examples use `EvolutionAPIClient` directly (async). They are runnable once `EVOLUTION_API_API_KEY` and `EVOLUTION_API_BASE_URL` are set.
+Once the MCP server is running, interact with Claude in natural language. Claude will use the Evolution API MCP tools to execute your requests.
 
-1) Send a text message
+### 1) Send a text message
 
-```python
-import asyncio
-from automagik_tools.tools.evolution_api.client import EvolutionAPIClient
-from automagik_tools.tools.evolution_api.config import EvolutionAPIConfig
+> "Send a WhatsApp message to +15551234567 using my-instance: 'Hello from Evolution API!'"
 
-async def send_text():
-    cfg = EvolutionAPIConfig()  # will read env vars
-    client = EvolutionAPIClient(cfg)
+Claude will use the `send_text_message` tool and return the message status.
 
-    res = await client.send_text_message(
-        instance="my-instance",
-        number="+15551234567",
-        message="Hello from Evolution API!",
-        delay=0,
-        linkPreview=True,
-    )
-    print(res)
+### 2) Send an image with caption
 
-asyncio.run(send_text())
-```
+> "Send this photo to +15551234567 on my-instance with caption 'Here is a photo': https://example.com/photo.jpg"
 
-2) Send an image (media) by URL
+Claude will automatically detect this is a media message and use the `send_media` tool.
 
-```python
-import asyncio
-from automagik_tools.tools.evolution_api.client import EvolutionAPIClient
-from automagik_tools.tools.evolution_api.config import EvolutionAPIConfig
+### 3) Send an audio message
 
-async def send_image():
-    cfg = EvolutionAPIConfig()
-    client = EvolutionAPIClient(cfg)
+> "Send this voice message to +15551234567 on my-instance: https://example.com/voice.mp3"
 
-    res = await client.send_media(
-        instance="my-instance",
-        number="+15551234567",
-        media="https://example.com/photo.jpg",
-        mediatype="image",
-        mimetype="image/jpeg",
-        caption="Here is a photo",
-        fileName="photo.jpg",
-    )
-    print(res)
+Claude will use the `send_audio` tool to send the audio file.
 
-asyncio.run(send_image())
-```
+### 4) Send other message types
 
-3) Send an audio message (base64 or URL)
+> "Send my store location to +15551234567 on my-instance: latitude 37.7749, longitude -122.4194, name 'My Store', address '123 Main St'"
 
-```python
-import asyncio
-from automagik_tools.tools.evolution_api.client import EvolutionAPIClient
-from automagik_tools.tools.evolution_api.config import EvolutionAPIConfig
+> "Send a thumbs up reaction 👍 to message 3EB0XXXXX for user 1234567890@s.whatsapp.net on my-instance"
 
-async def send_audio():
-    cfg = EvolutionAPIConfig()
-    client = EvolutionAPIClient(cfg)
+> "Show a typing indicator to +15551234567 on my-instance"
 
-    # audio can be a base64 string or a direct URL
-    res = await client.send_audio(
-        instance="my-instance",
-        number="+15551234567",
-        audio="https://example.com/voice.mp3",
-        delay=0,
-    )
-    print(res)
-
-asyncio.run(send_audio())
-```
-
-Notes on examples:
-- When `EVOLUTION_API_FIXED_RECIPIENT` is set, the `number` values above will be ignored and the fixed recipient will be used instead.
-- If you prefer MCP-level examples, run the tool with `uvx automagik-tools tool evolution_api` and then call the MCP function from your agent or an MCP client.
+### Notes
+- When `EVOLUTION_API_FIXED_RECIPIENT` is set, all messages go to that number regardless of what you specify
+- Claude automatically selects the appropriate tool (send_text_message, send_media, send_audio, etc.) based on your request
+- You can ask Claude for confirmation before sending: "Draft a WhatsApp message to... but don't send it yet"
 
 ## Fixed-recipient security feature
 

--- a/automagik_tools/tools/omni/README.md
+++ b/automagik_tools/tools/omni/README.md
@@ -89,27 +89,19 @@ Comprehensive instance management for all messaging channels.
 - `restart` - Restart instance connection
 - `logout` - Logout/disconnect instance
 
-**Examples:**
-```python
-# List all instances
-manage_instances(operation="list")
+**Usage (Natural Language):**
 
-# Get instance details
-manage_instances(operation="get", instance_name="my-whatsapp")
+Once the MCP server is running, interact with Claude in natural language:
 
-# Create new WhatsApp instance
-manage_instances(
-    operation="create",
-    config={
-        "name": "business-whatsapp",
-        "channel_type": "whatsapp",
-        "auto_qr": True
-    }
-)
+> "List all my messaging instances"
 
-# Get QR code for connection
-manage_instances(operation="qr", instance_name="my-whatsapp")
-```
+> "Show me details for the my-whatsapp instance"
+
+> "Create a new WhatsApp instance called business-whatsapp with auto QR code generation"
+
+> "Get the QR code for my-whatsapp instance so I can connect"
+
+Claude will use the `manage_instances` MCP tool to execute these requests and return the results.
 
 ### 2. `send_message`
 
@@ -123,52 +115,21 @@ Unified interface for sending all message types.
 - `contact` - Send contact cards
 - `reaction` - Send emoji reactions
 
-**Examples:**
-```python
-# Send text message
-send_message(
-    message_type="text",
-    phone="+1234567890",
-    message="Hello from OMNI!"
-)
+**Usage (Natural Language):**
 
-# Send image with caption
-send_message(
-    message_type="media",
-    phone="+1234567890",
-    media_url="https://example.com/image.jpg",
-    media_type="image",
-    caption="Check out this image!"
-)
+Talk to Claude naturally to send any type of message:
 
-# Send voice note
-send_message(
-    message_type="audio",
-    phone="+1234567890",
-    audio_url="https://example.com/voice.mp3"
-)
+> "Send a text message to +1234567890: 'Hello from OMNI!'"
 
-# Send reaction
-send_message(
-    message_type="reaction",
-    phone="+1234567890",
-    message_id="msg_123",
-    emoji="👍"
-)
+> "Send this image to +1234567890 with caption 'Check out this image!': https://example.com/image.jpg"
 
-# Send contact
-send_message(
-    message_type="contact",
-    phone="+1234567890",
-    contacts=[
-        {
-            "full_name": "John Doe",
-            "phone_number": "+0987654321",
-            "email": "john@example.com"
-        }
-    ]
-)
-```
+> "Send a voice note to +1234567890: https://example.com/voice.mp3"
+
+> "React with a thumbs up 👍 to message msg_123 for +1234567890"
+
+> "Send contact card for John Doe (+0987654321, john@example.com) to +1234567890"
+
+Claude will automatically choose the correct message type and use the `send_message` MCP tool.
 
 ### 3. `manage_traces`
 
@@ -182,35 +143,17 @@ Comprehensive trace management for debugging and analytics.
 - `by_phone` - Get traces for specific phone
 - `cleanup` - Clean up old traces
 
-**Examples:**
-```python
-# List recent traces
-manage_traces(
-    operation="list",
-    instance_name="my-whatsapp",
-    limit=20
-)
+**Usage (Natural Language):**
 
-# Get analytics
-manage_traces(
-    operation="analytics",
-    start_date="2024-01-01",
-    instance_name="my-whatsapp"
-)
+> "List the 20 most recent message traces for my-whatsapp instance"
 
-# Get traces for phone
-manage_traces(
-    operation="by_phone",
-    phone="+1234567890"
-)
+> "Show me analytics for my-whatsapp instance starting from January 1st, 2024"
 
-# Preview cleanup (dry run)
-manage_traces(
-    operation="cleanup",
-    days_old=30,
-    dry_run=True
-)
-```
+> "Get all message traces for phone number +1234567890"
+
+> "Preview cleaning up traces older than 30 days (dry run first)"
+
+Claude will use the `manage_traces` MCP tool to provide debugging and analytics information.
 
 ### 4. `manage_profiles`
 
@@ -220,20 +163,13 @@ Profile management operations.
 - `fetch` - Fetch user profile information
 - `update_picture` - Update instance profile picture
 
-**Examples:**
-```python
-# Fetch user profile
-manage_profiles(
-    operation="fetch",
-    phone_number="+1234567890"
-)
+**Usage (Natural Language):**
 
-# Update profile picture
-manage_profiles(
-    operation="update_picture",
-    picture_url="https://example.com/profile.jpg"
-)
-```
+> "Fetch the profile information for +1234567890"
+
+> "Update my profile picture to this image: https://example.com/profile.jpg"
+
+Claude will use the `manage_profiles` MCP tool to handle profile operations.
 
 ## Advanced Usage
 
@@ -245,43 +181,27 @@ Set a default instance to avoid specifying it for every operation:
 export OMNI_DEFAULT_INSTANCE=my-whatsapp
 ```
 
-Then you can omit `instance_name` in operations:
-```python
-# Will use default instance
-send_message(message_type="text", phone="+1234567890", message="Hello!")
-```
+Then Claude can automatically use the default instance:
+
+> "Send a message to +1234567890: 'Hello!'"
+
+(Claude will automatically use the default instance without you needing to specify it)
 
 ### Filtering Traces
 
-The trace management supports comprehensive filtering:
+The trace management supports comprehensive filtering. Just ask Claude naturally:
 
-```python
-manage_traces(
-    operation="list",
-    instance_name="my-whatsapp",
-    trace_status="failed",          # Filter by status
-    message_type="media",            # Filter by type
-    has_media=True,                  # Only media messages
-    start_date="2024-01-01",        # Date range
-    end_date="2024-01-31",
-    limit=100
-)
-```
+> "List failed message traces for my-whatsapp instance from January 1-31, 2024, only show media messages, limit to 100 results"
+
+Claude will apply all the appropriate filters when calling the `manage_traces` MCP tool.
 
 ### Bulk Operations
 
-While the tool doesn't explicitly support bulk operations, you can easily script them:
+Claude can help coordinate sending to multiple recipients:
 
-```python
-# Send message to multiple recipients
-recipients = ["+1234567890", "+0987654321", "+1111111111"]
-for phone in recipients:
-    send_message(
-        message_type="text",
-        phone=phone,
-        message="Bulk message to all!"
-    )
-```
+> "Send the message 'Bulk message to all!' to these numbers: +1234567890, +0987654321, +1111111111"
+
+Claude will iterate through the recipients and use the `send_message` MCP tool for each one.
 
 ## Error Handling
 


### PR DESCRIPTION
Fixes #18

## Problem

Tool READMEs (Omni and Evolution API) showed Python code examples, but MCP tools are used via **natural language** through AI agents like Claude, not by writing Python code.

## Changes

### Before (Python code):
```python
send_message(
    message_type="text",
    phone="+1234567890",
    message="Hello!"
)
```

### After (Natural language):
> "Send a text message to +1234567890: 'Hello!'"

## Files Changed

- `automagik_tools/tools/omni/README.md` - Replaced all Python examples with natural language
- `automagik_tools/tools/evolution_api/README.md` - Replaced Python client examples with Claude interactions

## Impact

- **81 additions, 205 deletions** - Removed verbose Python code, added concise natural language examples
- Documentation now matches actual MCP usage pattern
- Aligns with main README.md (lines 129-162)
- Makes tools feel more accessible and easier to use

## Context

This fixes our documentation debt identified during Hacktoberfest reviews:
- PR #17: Requested changes for showing Python code (same issue)
- PR #16: Merged Evolution API README that followed old Omni template
- Issue #18: Created to track fixing this across all tool READMEs

We're taking responsibility for fixing our own template issues.