### PR TITLE
fix: Change update_source HTTP method from PUT to PATCH

### DIFF
--- a/automagik_tools/tools/spark/client.py
+++ b/automagik_tools/tools/spark/client.py
@@ -276,7 +276,9 @@ class SparkClient:
             data["url"] = url
         if api_key:
             data["api_key"] = api_key
-        return await self.request("PUT", f"/api/v1/sources/{source_id}", json_data=data)
+        return await self.request(
+            "PATCH", f"/api/v1/sources/{source_id}", json_data=data
+        )
 
     async def delete_source(self, source_id: str) -> Dict[str, Any]:
         """Delete a source"""


### PR DESCRIPTION
## Summary
Fixes the `update_source` MCP tool to use the correct HTTP method (PATCH instead of PUT).

## Problem
The Spark API endpoint `PATCH /api/v1/sources/{source_id}` only accepts PATCH requests, but the `update_source` tool was using PUT, which caused HTTP 405 Method Not Allowed errors.

## Changes
- Changed HTTP method in `SparkClient.update_source()` from `PUT` to `PATCH` (automagik_tools/tools/spark/client.py:279)

## Testing
- ✅ All existing tests pass
- ✅ `test_update_source` - Tool functionality test
- ✅ `test_update_source_error` - Error handling test  
- ✅ `test_client_update_source` - Client method test

## Related Issue
Closes #24

## API Reference
The Spark API requires PATCH for partial updates:
```
PATCH /api/v1/sources/{source_id}
```