### PR TITLE
Fix: Update genie-omni create_server() to accept config parameter

### DIFF
--- a/automagik_tools/tools/genie-omni/__init__.py
+++ b/automagik_tools/tools/genie-omni/__init__.py
@@ -28,6 +28,19 @@ def get_config_class():
     return OmniConfig
 
 
-def create_server():
-    """Return the MCP server instance."""
+def create_server(server_config: OmniConfig | None = None):
+    """Return the MCP server instance.
+
+    Args:
+        server_config: Optional configuration for the Omni client
+
+    Returns:
+        The MCP server instance
+    """
+    from .server import initialize_client
+
+    # Initialize client with config if provided
+    if server_config:
+        initialize_client(server_config)
+
     return mcp

--- a/automagik_tools/tools/genie-omni/server.py
+++ b/automagik_tools/tools/genie-omni/server.py
@@ -27,6 +27,16 @@ mcp = FastMCP("genie-omni")
 _client: Optional[OmniClient] = None
 
 
+def initialize_client(config: OmniConfig) -> None:
+    """Initialize the global client with a specific config.
+
+    Args:
+        config: Configuration for the Omni client
+    """
+    global _client
+    _client = OmniClient(config)
+
+
 def get_client() -> OmniClient:
     """Get or create Omni client."""
     global _client


### PR DESCRIPTION
## Summary
Fixes TypeError when loading genie-omni tool by updating `create_server()` to accept the config parameter that the CLI passes to all tools.

## Changes
- Updated `create_server()` signature to accept optional `OmniConfig` parameter
- Added `initialize_client()` function in server.py to handle config initialization
- Follows same pattern as other tools (e.g., evolution_api)

## Test Plan
- [x] Tested with `uv run automagik-tools tool genie-omni --transport stdio`
- [x] Verified no more TypeError
- [x] Follows established tool patterns

## Fixes
Resolves: `TypeError: create_server() takes 0 positional arguments but 1 was given`