### PR TITLE
feat: Add respond_to_event function for calendar invite responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "automagik-tools"
-version = "0.9.10"
+version = "0.9.11"
 description = "A monorepo package for MCP tools with dynamic loading capabilities - featuring Evolution API v2 WhatsApp integration"
 authors = [
     {name = "Felipe Rosa", email = "felipe@namastex.ai"},


### PR DESCRIPTION
- Added new respond_to_event() tool to handle calendar RSVP
- Supports accepted, declined, tentative, needsAction responses
- Automatically updates attendee status in Google Calendar
- Sends update notifications to other attendees (configurable)
- Bumped version to 0.9.11

Fixes missing RSVP functionality that prevented programmatic acceptance/decline of calendar invitations.

## 🔗 Linked Issue/Wish (Optional but Recommended)

<!-- Link to issue using GitHub keywords below (one per line): -->
<!-- - Closes #123 -->
<!-- - Fixes #456 -->
<!-- - Resolves #789 -->

<!-- Or reference wish implementation: -->
<!-- Implements: .genie/wishes/my-feature.md -->

**Linked Issues:**
<!-- - Closes #number or N/A -->

**Wish Path:**
<!-- .genie/wishes/file.md or N/A -->

---

## 📝 Summary

<!-- Brief description of what this PR does -->

---

## 🔧 Changes Implemented

<!-- Bulleted list or sections of changes -->

1. **Component 1**
   - Change A
   - Change B

2. **Component 2**
   - Change C

---

## ✅ Testing

<!-- What testing was done? -->

- [ ] Tests added/updated
- [ ] All tests passing locally
- [ ] Manual testing completed

<!-- Add testing details if needed -->

---

## 💥 Breaking Changes

<!-- Does this introduce breaking changes? -->

- [ ] Yes (describe migration path below)
- [x] No

<!-- If yes, describe migration path: -->

---

## 📸 Screenshots/Evidence (Optional)

<!-- Add screenshots, logs, or other evidence -->

<details>
<summary>Before/After</summary>

<!-- Images or code snippets here -->

</details>

---

## 📚 Additional Context (Optional)

<!-- Any other relevant information -->

---

<!--
🤖 Automation Notes:
- If issue linked: PR inherits labels (type:*, priority:*, area:*) from issue
- If wish path provided: PR marked for archival on merge
- No issue link required for quick fixes, typos, or external contributions
-->
